### PR TITLE
Fix typo in TF-IDF example

### DIFF
--- a/embeddings.tex
+++ b/embeddings.tex
@@ -1202,7 +1202,7 @@ text_titles = ["quote_langstonhughes", "quote_william_blake"]
 
 vectorizer = TfidfVectorizer()
 vector = vectorizer.fit_transform(corpus)
-dict(zip(vectorizer.get_feature_names_out(), X.toarray()[0]))
+dict(zip(vectorizer.get_feature_names_out(), vector.toarray()[0]))
 
 tfidf_df = pd.DataFrame(vector.toarray(), index=text_titles, columns=vectorizer.get_feature_names_out())
 


### PR DESCRIPTION
A tiny typo-fix to match the [notebook](https://github.com/veekaybee/what_are_embeddings/blob/d51b6c0527624d6ecfdf26a831f7475631e9b671/notebooks/fig_24_tf_idf_from_scratch.ipynb#L558) that's in the repo
